### PR TITLE
Fix race conditions in threaded code

### DIFF
--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -354,8 +354,8 @@ PyObject *arg):
         block_hash = hash(get_frame_code(py_frame))
         code_hash = compute_line_hash(block_hash, py_frame.f_lineno)
         if self._c_code_map.count(code_hash):
-            ident = threading.get_ident()
             time = hpTimer()
+            ident = threading.get_ident()
             if self._c_last_time[ident].count(block_hash):
                 old = self._c_last_time[ident][block_hash]
                 line_entries = self._c_code_map[code_hash]


### PR DESCRIPTION
Hi and thanks for your work on line-profiler. I realize this is a fork, but it looks like it will be merged in soon (https://github.com/pyutils/line_profiler/pull/165) so I'm taking the chance to apply a fix here instead of on V3.x

Currently, line-profiler is inconsistent when used on threaded code. The lines of some functions do not show up in the output at all.
This stems from two problems:
 - Tracing must be enabled/disabled per-thread. Therefore, `enable_count` must be a thread-local variable, or different threads will step on each other toes. This was discovered in https://github.com/rkern/line_profiler/pull/10, but never merged, so I have re-implemented here
 - Similarly, `_c_last_time` must be thread-local as it is used by `disable`. I don't know enough Cython to implement this with `threading.local()`, so instead I changed `_c_last_time` to be a mapping between the thread id and the map of LastTime's

I'm not sure how much this will impact performance; I have not measured it. Please let me know if there is a better solution.
Finally, here's a simple test case to show the issue:
```
from line_profiler import LineProfiler
import time
import threading

prof = LineProfiler()

@prof
def f():
    time.sleep(0.1)  # This line won't show up in the output file

@prof
def f2():
    t = threading.Thread(target=f)
    t.start()
    t.join()  # Or sometimes this one

f2()
```