### PR TITLE
`LineProfilerMagics` refactoring, coverage boost, other fixes

### DIFF
--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -28,10 +28,21 @@ To get usage help for %lprun and %%lprun_all, use the standard IPython help mech
 """
 
 import ast
+import builtins
 import os
 import tempfile
 import textwrap
 import time
+from dataclasses import dataclass
+from functools import cached_property, partial
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Union
+if TYPE_CHECKING:
+    from types import CodeType  # noqa: F401
+    from typing import Callable, ParamSpec, ClassVar, TypeVar  # noqa: F401
+
+    PS = ParamSpec('PS')
+    DefNode = TypeVar('DefNode', ast.FunctionDef, ast.AsyncFunctionDef)
 
 from io import StringIO
 
@@ -41,7 +52,7 @@ from IPython.core.page import page
 from IPython.utils.ipstruct import Struct
 from IPython.core.error import UsageError
 
-from line_profiler import LineProfiler
+from line_profiler import LineProfiler, LineStats
 from line_profiler.autoprofile.ast_tree_profiler import AstTreeProfiler
 from line_profiler.autoprofile.ast_profile_transformer import AstProfileTransformer
 
@@ -71,9 +82,10 @@ class SkipWrapper(AstProfileTransformer):
             **kwargs: Keyword args forwarded to the parent transformer.
         """
         super().__init__(*args, **kwargs)
-        self._wrapper_name = wrapper_name
+        self._wrapper_name = wrapper_name  # type: str
 
     def _strip_profile_from_decorators(self, node):
+        # type: (DefNode) -> DefNode
         """Remove any @profile decorator from a function node.
 
         Handles both the bare decorator form (@profile) and the callable form
@@ -106,6 +118,7 @@ class SkipWrapper(AstProfileTransformer):
         return node
 
     def visit_FunctionDef(self, node):
+        # type: (ast.FunctionDef) -> ast.FunctionDef
         """Visit a synchronous "def" function.
 
         We first delegate to the base transformer so it can apply its logic
@@ -127,6 +140,7 @@ class SkipWrapper(AstProfileTransformer):
     # This isn't needed by our code because our _lprof_cell will never be async,
     # but it's included in case a user needs to make it async to work with their code
     def visit_AsyncFunctionDef(self, node):
+        # type: (ast.AsyncFunctionDef) -> ast.AsyncFunctionDef
         """Visit an asynchronous "async def" function.
 
         Mirrors visit_FunctionDef but for async functions. After the base
@@ -145,13 +159,224 @@ class SkipWrapper(AstProfileTransformer):
         return node
 
 
+@dataclass
+class _ParseParamResult:
+    """ Class for holding parsed info relevant to the behaviors of both
+    the ``%lprun`` and ``%%lprun_all`` magics.
+
+    Attributes:
+        ``.opts``
+            :py:class:`IPython.utils.ipstruct.Struct` object.
+        ``.arg_str``
+            :py:class:`str` of unparsed argument(s).
+        ``.dump_raw_dest``
+            (Descriptor) :py:class:`pathlib.Path` to write the raw
+            (pickled) profiling results to, or :py:data:`None` if not to
+            be written.
+        ``.dump_text_dest``
+            (Descriptor) :py:class:`pathlib.Path` to write the
+            plain-text profiling results to, or :py:data:`None` if not
+            to be written.
+        ``.output_unit``
+            (Descriptor) Unit to normalize the output of
+            :py:meth:`line_profiler.LineProfiler.print_stats` to, or
+            :py:data:`None` if not specified.
+        ``.strip_zero``
+            (Descriptor) Whether to call
+            :py:meth:`line_profiler.LineProfiler.print_stats` with
+            ``stripzeros=True``.
+        ``.return_profiler``
+            (Descriptor) Whether the
+            :py:class:`line_profiler.LineProfiler` instance is to be
+            returned.
+    """
+    opts: Struct
+    arg_str: str
+
+    def __getattr__(self, attr):  # type: (str) -> Any
+        """ Defers to :py:attr:`_ParseParamResult.opts`."""
+        return getattr(self.opts, attr)
+
+    def __getitem__(self, key):  # type: (str) -> Any
+        """ Defers to :py:attr:`_ParseParamResult.opts`."""
+        return self.opts[key]
+
+    @cached_property
+    def dump_raw_dest(self):  # type: () -> Path | None
+        path = self.opts.D[0]
+        if path:
+            return Path(path)
+        return None
+
+    @cached_property
+    def dump_text_dest(self):  # type: () -> Path | None
+        path = self.opts.T[0]
+        if path:
+            return Path(path)
+        return None
+
+    @cached_property
+    def output_unit(self):  # type: () -> float | None
+        if self.opts.u is None:
+            return None
+        try:
+            return float(self.opts.u[0])
+        except Exception:
+            raise TypeError("Timer unit setting must be a float.")
+
+    @cached_property
+    def strip_zero(self):  # type: () -> bool
+        return "z" in self.opts
+
+    @cached_property
+    def return_profiler(self):  # type: () -> bool
+        return "r" in self.opts
+
+
+@dataclass
+class _RunAndProfileResult:
+    """ Class for holding the results of both the ``%lprun`` and
+    ``%%lprun_all`` magics.
+    """
+    stats: LineStats
+    parse_result: _ParseParamResult
+    return_value: Any
+    message: Union[str, None] = None
+    time_elapsed: Union[float, None] = None
+
+    def __post_init__(self):
+        self.output  # Fetch value
+
+    @cached_property
+    def output(self):  # type: () -> str
+        with StringIO() as capture:  # Trap text output
+            self.stats.print(capture,
+                             output_unit=self.parse_result.output_unit,
+                             stripzeros=self.parse_result.strip_zero)
+            return capture.getvalue().rstrip()
+
+
+class _PatchProfilerIntoBuiltins:
+    """
+    Example:
+        >>> import builtins
+        >>> from line_profiler import LineProfiler
+        >>>
+        >>>
+        >>> prof = LineProfiler()
+        >>> with _PatchProfilerIntoBuiltins(prof):
+        ...     assert builtins.profile is prof
+        ...
+        >>> print(builtins.profile)
+        Traceback (most recent call last):
+          ...
+        AttributeError: ...
+    """
+    def __init__(self, prof=None):
+        self.prof = prof or LineProfiler()  # type: LineProfiler
+        self._namespace = vars(builtins)  # type: dict[str, Any]
+        self._state = False, None  # type: tuple[bool, Any]
+
+    def __enter__(self):  # type: () -> LineProfiler
+        try:
+            self._state = True, self._namespace['profile']
+        except KeyError:
+            self._state = False, None
+        # Add the profiler to the builtins for @profile.
+        self._namespace['profile'] = self.prof
+        return self.prof
+
+    def __exit__(self, *_, **__):
+        self._state, (had_profile, old_profile) = (False, None), self._state
+        if had_profile:
+            self._namespace['profile'] = old_profile
+        else:
+            self._namespace.pop('profile', None)
+
+
 @magics_class
 class LineProfilerMagics(Magics):
-    def parse_parameters(self, parameter_s):
-        # FIXME: There is a chance that this handling will need to be updated
-        # to handle single-quoted characters better (#382)
+    def _parse_parameters(self, parameter_s, getopt_spec, opts_def):
+        # type: (str, str, Struct) -> _ParseParamResult
+        # FIXME: There is a chance that this handling will need to be
+        # updated to handle single-quoted characters better (#382)
         parameter_s = parameter_s.replace('"', r"\"").replace("'", r"\"")
-        return parameter_s
+
+        opts, arg_str = self.parse_options(
+            parameter_s, getopt_spec, list_all=True)
+        opts.merge(opts_def)
+        return _ParseParamResult(opts, arg_str)
+
+    @staticmethod
+    def _run_and_profile(prof,  # type: LineProfiler
+                         parse_result,  # type: _ParseParamResult
+                         method,  # type: Callable[PS, Any]
+                         *args,  # type: PS.args
+                         **kwargs,  # type: PS.kwargs
+                         ):  # type: (...) -> _RunAndProfileResult
+        # Use the time module because it's easier than parsing the
+        # output from `show_text()`.
+        # `perf_counter()` is a monotonically increasing alternative to
+        # `time()` that's intended for simple benchmarking.
+        start_time = time.perf_counter()
+        try:
+            return_value = method(*args, **kwargs)
+            message = None
+        except (SystemExit, KeyboardInterrupt) as e:
+            message = (f"{type(e).__name__} exception caught in "
+                       "code being profiled.")
+
+        # Capture and save total runtime
+        total_time = time.perf_counter() - start_time
+        return _RunAndProfileResult(
+            prof.get_stats(), parse_result, return_value, message, total_time)
+
+    @classmethod
+    def _lprun_all_get_rewritten_profiled_code(cls, tmpfile):
+        # type: (str) -> CodeType
+        # Run the AST transformer on the temp file, while skipping the
+        # wrapper function.
+        get_transformer = partial(SkipWrapper,
+                                  wrapper_name=cls._lprof_all_fname)
+        at = AstTreeProfiler(
+            tmpfile,
+            [tmpfile],
+            profile_imports=False,
+            ast_transformer_class_handler=get_transformer)  # type: ignore[arg-type]
+        tree = at.profile()
+
+        # Compile and exec that AST. This is similar to `prof.runctx`,
+        # but that doesn't support executing AST.
+        return compile(tree, tmpfile, "exec")
+
+    @classmethod
+    def _lprun_get_top_level_profiled_code(cls, tmpfile):
+        # type: (str) -> CodeType
+        # Compile and define the function from that file.
+        with open(tmpfile, mode='r') as fobj:
+            return compile(fobj.read(), tmpfile, "exec")
+
+    @staticmethod
+    def _handle_end(prof, run_result):
+        # type: (LineProfiler, _RunAndProfileResult) -> LineProfiler | None
+        page(run_result.output)
+
+        dump_file = run_result.parse_result.dump_raw_dest
+        if dump_file is not None:
+            prof.dump_stats(dump_file)
+            print(f"\n*** Profile stats pickled to file {str(dump_file)!r}.")
+
+        text_file = run_result.parse_result.dump_text_dest
+        if text_file is not None:
+            with text_file.open("w", encoding="utf-8") as pfile:
+                print(run_result.output, file=pfile)
+            print("\n*** Profile printout saved to text file "
+                  f"{str(text_file)!r}.")
+
+        if run_result.message:
+            print("\n*** " + run_result.message)
+
+        return prof if run_result.parse_result.return_profiler else None
 
     @line_magic
     def lprun(self, parameter_s=""):
@@ -190,35 +415,34 @@ class LineProfilerMagics(Magics):
 
         -s: strip out all entries from the print-out that have zeros.
         This is an old alias for -z.
-        
+
         -z: strip out all entries from the print-out that have zeros.
 
         -u: specify time unit for the print-out in seconds.
         """
-
-        # Escape quote markers.
-        parameter_s = self.parse_parameters(parameter_s)
         opts_def = Struct(D=[""], T=[""], f=[], m=[], u=None)
-        opts, arg_str = self.parse_options(parameter_s, "rszf:m:D:T:u:", list_all=True)
-        opts.merge(opts_def)
+        parsed = self._parse_parameters(parameter_s, "rszf:m:D:T:u:", opts_def)
+        if "s" in parsed.opts:  # Handle alias
+            parsed.opts["z"] = True
 
+        assert self.shell is not None
         global_ns = self.shell.user_global_ns
         local_ns = self.shell.user_ns
 
         # Get the requested functions.
         funcs = []
-        for name in opts.f:
+        for name in parsed.f:
             try:
                 funcs.append(eval(name, global_ns, local_ns))
             except Exception as e:
                 raise UsageError(
-                    f"Could not find module {name}.\n{e.__class__.__name__}: {e}"
+                    f"Could not find function {name}.\n{e.__class__.__name__}: {e}"
                 )
 
         profile = LineProfiler(*funcs)
 
         # Get the modules, too
-        for modname in opts.m:
+        for modname in parsed.m:
             try:
                 mod = __import__(modname, fromlist=[""])
                 profile.add_module(mod)
@@ -227,76 +451,21 @@ class LineProfilerMagics(Magics):
                     f"Could not find module {modname}.\n{e.__class__.__name__}: {e}"
                 )
 
-        if opts.u is not None:
-            try:
-                output_unit = float(opts.u[0])
-            except Exception:
-                raise TypeError("Timer unit setting must be a float.")
-        else:
-            output_unit = None
+        with _PatchProfilerIntoBuiltins(profile):
+            run = self._run_and_profile(
+                profile, parsed, profile.runctx, parsed.arg_str,
+                globals=global_ns, locals=local_ns)
 
-        # Add the profiler to the builtins for @profile.
-        import builtins
-
-        if "profile" in builtins.__dict__:
-            had_profile = True
-            old_profile = builtins.__dict__["profile"]
-        else:
-            had_profile = False
-            old_profile = None
-        builtins.__dict__["profile"] = profile
-
-        try:
-            try:
-                profile.runctx(arg_str, global_ns, local_ns)
-                message = ""
-            except SystemExit:
-                message = """*** SystemExit exception caught in code being profiled."""
-            except KeyboardInterrupt:
-                message = (
-                    "*** KeyboardInterrupt exception caught in code being " "profiled."
-                )
-        finally:
-            if had_profile:
-                builtins.__dict__["profile"] = old_profile
-
-        # Trap text output.
-        stdout_trap = StringIO()
-        profile.print_stats(
-            stdout_trap, output_unit=output_unit, stripzeros=("s" in opts or "z" in opts)
-        )
-        output = stdout_trap.getvalue()
-        output = output.rstrip()
-
-        page(output)
-        print(message, end="")
-
-        dump_file = opts.D[0]
-        if dump_file:
-            profile.dump_stats(dump_file)
-            print(f"\n*** Profile stats pickled to file {dump_file!r}. {message}")
-
-        text_file = opts.T[0]
-        if text_file:
-            pfile = open(text_file, "w", encoding="utf-8")
-            pfile.write(output)
-            pfile.close()
-            print(f"\n*** Profile printout saved to text file {text_file!r}. {message}")
-
-        return_value = None
-        if "r" in opts:
-            return_value = profile
-
-        return return_value
+        return self._handle_end(profile, run)
 
     @cell_magic
-    def lprun_all(self, parameter_s="", cell=None):
+    def lprun_all(self, parameter_s="", cell=""):
         """Execute the whole notebook cell under the line-by-line profiler from the
         line_profiler module.
 
         Usage:
 
-            %lprun_all <options>
+            %%lprun_all <options>
 
         By default, without the -p option, it includes nested functions in the profiler.
         The statistics will be shown side-by-side with the code through the pager
@@ -328,178 +497,55 @@ class LineProfilerMagics(Magics):
         -p: Profile only top-level code (ignore nested functions). Using this can bypass
         any issues with ast transformation.
         """
-        parameter_s = self.parse_parameters(parameter_s)
         opts_def = Struct(D=[""], T=[""], u=None)
-        opts, arg_str = self.parse_options(parameter_s, "rzptD:T:u:", list_all=True)
-        opts.merge(opts_def)
+        parsed = self._parse_parameters(parameter_s, "rzptD:T:u:", opts_def)
+
+        ip = get_ipython()
+        # We have to encase the cell being profiled in an outer function
+        # if we want this to work.
+        if not cell.strip():  # Edge case
+            cell = '...'
+        indented = textwrap.indent(cell, "    ")
+        fsrc = f"def {self._lprof_all_fname}():\n{indented}"
+
+        # Write the cell to a temporary file so `show_text()` inside
+        # `print_stats()` can open it.
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", delete=False, mode="w", encoding="utf-8"
+        ) as tf:
+            tf.write(fsrc)
 
         try:
-            # This function is injected into the namespace by IPython,
-            # so linting doesn't pick it up. We use noqa to ignore the linting error.
-            ip = get_ipython() # noqa: F821
-        except NameError:
-            raise NameError("This function needs to be run inside an IPython instance!")
-        fname = "_lprof_cell"
-
-        # We have to encase the cell being profiled in an outer function if we want this to work.
-        indented = textwrap.indent(cell, "    ")
-        fsrc = f"def {fname}():\n{indented}"
-
-        # Write the cell to a temporary file so show_text inside print_stats can open it.
-        tf = tempfile.NamedTemporaryFile(
-            suffix=".py", delete=False, mode="w", encoding="utf-8"
-        )
-        tf.write(fsrc)
-        tf.flush()
-        tf.close()
-
-        if opts.u is not None:
-            try:
-                output_unit = float(opts.u[0])
-            except Exception:
-                raise TypeError("Timer unit setting must be a float.")
-        else:
-            output_unit = None
-
-        # Add the profiler to the builtins for @profile.
-        import builtins
-
-        # This is the default case.
-        if "p" not in opts:
+            if "p" not in parsed.opts:  # This is the default case.
+                get_code = self._lprun_all_get_rewritten_profiled_code
+            else:
+                get_code = self._lprun_get_top_level_profiled_code
             # Inject a fresh LineProfiler into @profile.
-            profile = LineProfiler()
-            had_profile = "profile" in builtins.__dict__
-            oldp = builtins.__dict__.get("profile", None)
-            builtins.__dict__["profile"] = profile
-
-            # Run the AST transformer on the temp file, while skipping the wrapper function.
-            at = AstTreeProfiler(
-                tf.name,
-                [tf.name],
-                profile_imports=False,
-                ast_transformer_class_handler=lambda *a, **k: SkipWrapper(
-                    *a, wrapper_name=fname, **k
-                ),
-            )
-            tree = at.profile()
-
-            # Compile and exec that AST. This is similar to profiler.runctx,
-            # but that doesn't support executing AST.
-            code = compile(tree, tf.name, "exec")
-            # We don't define ip.user_global_ns and ip.user_ns at the beginning like in lprun
-            # because the ns changes after the previous compile call.
-            exec(code, ip.user_global_ns, ip.user_ns)
-            # Grab and call the wrapper so it actually runs under @profile.
-            f = ip.user_ns.get(fname)
-            if f is None:
-                raise RuntimeError(f"No function {fname!r} defined after AST transform")
-            profile.add_function(f)
-            profile.enable_by_count()
-            # Use the time module because it's easier than parsing the output from show_text.
-            # perf_counter() is a monotonically increasing alternative to time() that's intended
-            # for simple benchmarking.
-            start_time = time.perf_counter()
-            # If this goes in a try/finally block, the output goes blank :(
-            try:
-                f()
-                message = ""
-            except SystemExit:
-                message = "*** SystemExit exception caught in code being profiled."
-            except KeyboardInterrupt:
-                message = (
-                    "*** KeyboardInterrupt exception caught in code being profiled."
-                )
-            finally:
-                # Clean up temp file.
-                os.unlink(tf.name)
-
-            total_time = time.perf_counter() - start_time
-            profile.disable_by_count()
-
-            # Restore existing profiles in builtins.
-            if had_profile:
-                builtins.__dict__["profile"] = oldp
-            else:
-                del builtins.__dict__["profile"]
-
-            # Trap text output.
-            # I tried deduplicating this code by moving it outside of the if/else
-            # but that ended up causing the line content output to go blank.
-            trap = StringIO()
-            profile.print_stats(trap, output_unit=output_unit, stripzeros="z" in opts)
-            page(trap.getvalue())
-
-            if "t" in opts:
-                # I know it seems redundant to include this because users could just use -r
-                # to get the info, but see the docstring for why -t is included anyway.
-                ip.user_ns["_total_time_taken"] = total_time
-        else:
-            # Compile and define the function from that file.
-            code = compile(fsrc, tf.name, "exec")
-            # We don't define ip.user_global_ns and ip.user_ns at the beginning like in lprun
-            # because the ns changes after the previous compile call.
-            exec(code, ip.user_global_ns, ip.user_ns)
-
-            f = ip.user_ns[fname]
-            profile = LineProfiler(f)
-
-            if "profile" in builtins.__dict__:
-                had_profile = True
-                old_profile = builtins.__dict__["profile"]
-            else:
-                had_profile = False
-                old_profile = None
-            builtins.__dict__["profile"] = profile
-
-            # Use the time module because it's easier than parsing the output from show_text.
-            start_time = time.perf_counter()
-            try:
+            with _PatchProfilerIntoBuiltins() as prof:
+                # We don't define `ip.user_global_ns` and `ip.user_ns`
+                # at the beginning like in lprun because the ns changes
+                # after the previous compile call.
+                exec(get_code(tf.name), ip.user_global_ns, ip.user_ns)
                 try:
-                    profile.runcall(f)
-                    message = ""
-                except SystemExit:
-                    message = "*** SystemExit exception caught in code being profiled."
-                except KeyboardInterrupt:
-                    message = (
-                        "*** KeyboardInterrupt exception caught in code being profiled."
-                    )
-            finally:
-                os.unlink(tf.name)
-                # Restore any previous @profile.
-                if had_profile:
-                    builtins.__dict__["profile"] = old_profile
-                else:
-                    del builtins.__dict__["profile"]
-            # Capture and save total runtime.
-            total_time = time.perf_counter() - start_time
-            if "t" in opts:
-                ip.user_ns["_total_time_taken"] = total_time
+                    # Grab and call the wrapper so it actually runs
+                    # under @profile.
+                    func = ip.user_ns[self._lprof_all_fname]
+                except KeyError:
+                    raise RuntimeError(
+                        f"No function {self._lprof_all_fname!r} defined "
+                        "after AST transform") from None
+                prof.add_function(func)
+                # This method fetches the `LineProfiler.print_stats()`
+                # output before the `os.unlink()` below happens
+                run = self._run_and_profile(prof, parsed, prof.runcall, func)
+        finally:
+            os.unlink(tf.name)
+        if "t" in parsed.opts:
+            # I know it seems redundant to include this because users
+            # could just use -r to get the info, but see the docstring
+            # for why -t is included anyway.
+            ip.user_ns["_total_time_taken"] = run.time_elapsed
 
-            # Trap text output.
-            stdout_trap = StringIO()
-            profile.print_stats(
-                stdout_trap, output_unit=output_unit, stripzeros="z" in opts
-            )
-            output = stdout_trap.getvalue()
-            output = output.rstrip()
+        return self._handle_end(prof, run)
 
-            page(output)
-            print(message, end="")
-
-        dump_file = opts.D[0]
-        if dump_file:
-            profile.dump_stats(dump_file)
-            print(f"\n*** Profile stats pickled to file {dump_file!r}. {message}")
-
-        text_file = opts.T[0]
-        if text_file:
-            pfile = open(text_file, "w", encoding="utf-8")
-            pfile.write(output)
-            pfile.close()
-            print(f"\n*** Profile printout saved to text file {text_file!r}. {message}")
-
-        return_value = None
-        if "r" in opts:
-            return_value = profile
-
-        return return_value
+    _lprof_all_fname = "_lprof_cell"  # type: ClassVar[str]

--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -1,14 +1,15 @@
 """
-This module defines the ``%lprun`` and ``%%lprun_all`` IPython magic functions.
+This module defines the |lprun| and |lprun_all| IPython magic functions.
 
-If you are using IPython, there is an implementation of an %lprun magic command
-which will let you specify functions to profile and a statement to execute. It
-will also add its LineProfiler instance into the __builtins__, but typically,
+If you are using IPython, there is an implementation of an |lprun| magic
+command which will let you specify functions to profile and a statement
+to execute.  It will also add its
+:py:class:`~.LineProfiler` instance into the |builtins|, but typically,
 you would not use it like that.
 
-You can also use %%lprun_all, which profiles the whole cell you're executing
-automagically, without needing to specify lines/functions yourself. It's meant
-for easier use for beginners.
+You can also use |lprun_all|, which profiles the whole cell you're
+executing automagically, without needing to specify lines/functions
+yourself.  It's meant for easier use for beginners.
 
 For IPython 0.11+, you can install it by editing the IPython configuration file
 ``~/.ipython/profile_default/ipython_config.py`` to add the ``'line_profiler'``
@@ -22,9 +23,14 @@ Or explicitly call::
 
     %load_ext line_profiler
 
-To get usage help for %lprun and %%lprun_all, use the standard IPython help mechanism::
+To get usage help for |lprun| and |lprun_all|, use the standard IPython
+help mechanism::
 
     In [1]: %lprun?
+
+.. |lprun| replace:: :py:data:`%%lprun <LineProfilerMagics.lprun>`
+.. |lprun_all| replace:: :py:data:`%%lprun_all <LineProfilerMagics.lprun_all>`
+.. |builtins| replace:: :py:mod:`__builtins__ <builtins>`
 """
 
 import ast
@@ -55,6 +61,9 @@ from IPython.core.error import UsageError
 from line_profiler import LineProfiler, LineStats
 from line_profiler.autoprofile.ast_tree_profiler import AstTreeProfiler
 from line_profiler.autoprofile.ast_profile_transformer import AstProfileTransformer
+
+
+__all__ = ('LineProfilerMagics',)
 
 
 # This is used for profiling all the code within a cell with lprun_all
@@ -381,44 +390,50 @@ class LineProfilerMagics(Magics):
     @line_magic
     def lprun(self, parameter_s=""):
         """Execute a statement under the line-by-line profiler from the
-        line_profiler module.
+        :py:mod:`line_profiler` module.
 
-        Usage:
+        Usage::
 
-            %lprun -f func1 -f func2 <statement>
+            %lprun [<options>] <statement>
 
-        The given statement (which doesn't require quote marks) is run via the
-        LineProfiler. Profiling is enabled for the functions specified by the -f
-        options. The statistics will be shown side-by-side with the code through the
-        pager once the statement has completed.
+        The given statement (which doesn't require quote marks) is run
+        via the :py:class:`~.LineProfiler`.  Profiling is enabled for
+        the functions specified by the ``-f`` options.  The statistics
+        will be shown side-by-side with the code through the pager once
+        the statement has completed.
 
         Options:
 
-        -f <function>: LineProfiler only profiles functions and methods it is told
-        to profile.  This option tells the profiler about these functions. Multiple
-        -f options may be used. The argument may be any expression that gives
-        a Python function or method object. However, one must be careful to avoid
-        spaces that may confuse the option parser.
+        ``-f <function>``: :py:class:`~.LineProfiler` only profiles
+        functions and methods it is told to profile.  This option tells
+        the profiler about these functions.  Multiple ``-f`` options may
+        be used.  The argument may be any expression that gives
+        a Python function or method object.  However, one must be
+        careful to avoid spaces that may confuse the option parser.
 
-        -m <module>: Get all the functions/methods in a module
+        ``-m <module>``: Get all the functions/methods in a module
 
-        One or more -f or -m options are required to get any useful results.
+        One or more ``-f`` or ``-m`` options are required to get any
+        useful results.
 
-        -D <filename>: dump the raw statistics out to a pickle file on disk. The
-        usual extension for this is ".lprof". These statistics may be viewed later
-        by running line_profiler.py as a script.
+        ``-D <filename>``: dump the raw statistics out to a pickle file
+        on disk.  The usual extension for this is ``.lprof``.  These
+        statistics may be viewed later by running
+        ``python -m line_profiler``.
 
-        -T <filename>: dump the text-formatted statistics with the code side-by-side
-        out to a text file.
+        ``-T <filename>``: dump the text-formatted statistics with the
+        code side-by-side out to a text file.
 
-        -r: return the LineProfiler object after it has completed profiling.
+        ``-r``: return the :py:class:`~.LineProfiler` object after it
+        has completed profiling.
 
-        -s: strip out all entries from the print-out that have zeros.
-        This is an old alias for -z.
+        ``-s``: strip out all entries from the print-out that have
+        zeros.  This is an old alias for ``-z``.
 
-        -z: strip out all entries from the print-out that have zeros.
+        ``-z``: strip out all entries from the print-out that have
+        zeros.
 
-        -u: specify time unit for the print-out in seconds.
+        ``-u``: specify time unit for the print-out in seconds.
         """
         opts_def = Struct(D=[""], T=[""], f=[], m=[], u=None)
         parsed = self._parse_parameters(parameter_s, "rszf:m:D:T:u:", opts_def)
@@ -460,42 +475,48 @@ class LineProfilerMagics(Magics):
 
     @cell_magic
     def lprun_all(self, parameter_s="", cell=""):
-        """Execute the whole notebook cell under the line-by-line profiler from the
-        line_profiler module.
+        """Execute the whole notebook cell under the line-by-line
+        profiler from the :py:mod:`line_profiler` module.
 
-        Usage:
+        Usage::
 
-            %%lprun_all <options>
+            %%lprun_all [<options>]
 
-        By default, without the -p option, it includes nested functions in the profiler.
-        The statistics will be shown side-by-side with the code through the pager
-        once the statement has completed.
+        By default, without the ``-p`` option, it includes nested
+        functions in the profiler.  The statistics will be shown
+        side-by-side with the code through the pager once the statement
+        has completed.
 
         Options:
 
-        -D <filename>: dump the raw statistics out to a pickle file on disk. The
-        usual extension for this is ".lprof". These statistics may be viewed later
-        by running line_profiler.py as a script.
+        ``-D <filename>``: dump the raw statistics out to a pickle file
+        on disk.  The usual extension for this is ``.lprof``.  These
+        statistics may be viewed later by running
+        ``python -m line_profiler``.
 
-        -T <filename>: dump the text-formatted statistics with the code side-by-side
-        out to a text file.
+        ``-T <filename>``: dump the text-formatted statistics with the
+        code side-by-side out to a text file.
 
-        -r: return the LineProfiler object after it has completed profiling.
+        ``-r``: return the :py:class:`~.LineProfiler` object after it
+        has completed profiling.
 
-        -z: strip out all entries from the print-out that have zeros. Note: this is -s in
-        lprun, however we use -z here for consistency with the CLI.
+        ``-z``: strip out all entries from the print-out that have
+        zeros.
 
-        -u: specify time unit for the print-out in seconds.
+        ``-u``: specify time unit for the print-out in seconds.
 
-        -t: store the total time taken (in seconds) to a variable called
-        `_total_time_taken` in your notebook. This can be useful if you want
-        to plot the total time taken for different versions of a code cell without
-        needing to manually look at and type down the time taken. This can be accomplished
-        with -r, but that would require a decent bit of boilerplate code and some knowledge
-        of the timings data structure, so this is added to be beginner-friendly.
+        ``-t``: store the total time taken (in seconds) to a variable
+        called ``_total_time_taken`` in your notebook.  This can be
+        useful if you want to plot the total time taken for different
+        versions of a code cell without needing to manually look at and
+        type down the time taken.  This can be accomplished with ``-r``,
+        but that would require a decent bit of boilerplate code and some
+        knowledge of the timings data structure, so this is added to be
+        beginner-friendly.
 
-        -p: Profile only top-level code (ignore nested functions). Using this can bypass
-        any issues with ast transformation.
+        ``-p``: Profile only top-level code (ignore nested functions).
+        Using this can bypass any issues with :py:mod:`ast`
+        transformations.
         """
         opts_def = Struct(D=[""], T=[""], u=None)
         parsed = self._parse_parameters(parameter_s, "rzptD:T:u:", opts_def)

--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -3,13 +3,13 @@ This module defines the |lprun| and |lprun_all| IPython magic functions.
 
 If you are using IPython, there is an implementation of an |lprun| magic
 command which will let you specify functions to profile and a statement
-to execute.  It will also add its
+to execute. It will also add its
 :py:class:`~.LineProfiler` instance into the |builtins|, but typically,
 you would not use it like that.
 
 You can also use |lprun_all|, which profiles the whole cell you're
 executing automagically, without needing to specify lines/functions
-yourself.  It's meant for easier use for beginners.
+yourself. It's meant for easier use for beginners.
 
 For IPython 0.11+, you can install it by editing the IPython configuration file
 ``~/.ipython/profile_default/ipython_config.py`` to add the ``'line_profiler'``
@@ -318,7 +318,7 @@ class LineProfilerMagics(Magics):
     @classmethod
     def _lprun_all_get_rewritten_profiled_code(cls, tmpfile):
         # type: (str) -> types.CodeType
-        """ Transform and compile the AST of the profiled code.  This is
+        """ Transform and compile the AST of the profiled code. This is
         similar to :py:meth:`.LineProfiler.runctx`,
         """
         at = AstTreeProfiler(tmpfile, [tmpfile], profile_imports=False)
@@ -365,18 +365,18 @@ class LineProfilerMagics(Magics):
             %lprun [<options>] <statement>
 
         The given statement (which doesn't require quote marks) is run
-        via the :py:class:`~.LineProfiler`.  Profiling is enabled for
-        the functions specified by the ``-f`` options.  The statistics
+        via the :py:class:`~.LineProfiler`. Profiling is enabled for
+        the functions specified by the ``-f`` options. The statistics
         will be shown side-by-side with the code through the pager once
         the statement has completed.
 
         Options:
 
         ``-f <function>``: :py:class:`~.LineProfiler` only profiles
-        functions and methods it is told to profile.  This option tells
-        the profiler about these functions.  Multiple ``-f`` options may
-        be used.  The argument may be any expression that gives
-        a Python function or method object.  However, one must be
+        functions and methods it is told to profile. This option tells
+        the profiler about these functions. Multiple ``-f`` options may
+        be used. The argument may be any expression that gives
+        a Python function or method object. However, one must be
         careful to avoid spaces that may confuse the option parser.
 
         ``-m <module>``: Get all the functions/methods in a module
@@ -385,7 +385,7 @@ class LineProfilerMagics(Magics):
         useful results.
 
         ``-D <filename>``: dump the raw statistics out to a pickle file
-        on disk.  The usual extension for this is ``.lprof``.  These
+        on disk. The usual extension for this is ``.lprof``. These
         statistics may be viewed later by running
         ``python -m line_profiler``.
 
@@ -396,7 +396,7 @@ class LineProfilerMagics(Magics):
         has completed profiling.
 
         ``-s``: strip out all entries from the print-out that have
-        zeros.  This is an old alias for ``-z``.
+        zeros. This is an old, soon-to-be-deprecated alias for ``-z``.
 
         ``-z``: strip out all entries from the print-out that have
         zeros.
@@ -451,14 +451,14 @@ class LineProfilerMagics(Magics):
             %%lprun_all [<options>]
 
         By default, without the ``-p`` option, it includes nested
-        functions in the profiler.  The statistics will be shown
+        functions in the profiler. The statistics will be shown
         side-by-side with the code through the pager once the statement
         has completed.
 
         Options:
 
         ``-D <filename>``: dump the raw statistics out to a pickle file
-        on disk.  The usual extension for this is ``.lprof``.  These
+        on disk. The usual extension for this is ``.lprof``. These
         statistics may be viewed later by running
         ``python -m line_profiler``.
 
@@ -469,15 +469,15 @@ class LineProfilerMagics(Magics):
         has completed profiling.
 
         ``-z``: strip out all entries from the print-out that have
-        zeros.
+        zeros. This is included for consistency with the CLI.
 
         ``-u``: specify time unit for the print-out in seconds.
 
         ``-t``: store the total time taken (in seconds) to a variable
-        called ``_total_time_taken`` in your notebook.  This can be
+        called ``_total_time_taken`` in your notebook. This can be
         useful if you want to plot the total time taken for different
         versions of a code cell without needing to manually look at and
-        type down the time taken.  This can be accomplished with ``-r``,
+        type down the time taken. This can be accomplished with ``-r``,
         but that would require a decent bit of boilerplate code and some
         knowledge of the timings data structure, so this is added to be
         beginner-friendly.

--- a/line_profiler/ipython_extension.pyi
+++ b/line_profiler/ipython_extension.pyi
@@ -3,13 +3,10 @@ from . import LineProfiler
 
 
 class LineProfilerMagics(Magics):
-    def parse_parameters(self, parameter_s: str) -> str:
-        ...
-
     def lprun(self, parameter_s: str = ...) -> LineProfiler | None:
         ...
 
     def lprun_all(self,
                   parameter_s: str = "",
-                  cell: str | None = None) -> LineProfiler | None:
+                  cell: str = "") -> LineProfiler | None:
         ...

--- a/line_profiler/ipython_extension.pyi
+++ b/line_profiler/ipython_extension.pyi
@@ -1,7 +1,15 @@
 from IPython.core.magic import Magics
+from . import LineProfiler
 
 
 class LineProfilerMagics(Magics):
+    def parse_parameters(self, parameter_s: str) -> str:
+        ...
 
-    def lprun(self, parameter_s: str = ...):
+    def lprun(self, parameter_s: str = ...) -> LineProfiler | None:
+        ...
+
+    def lprun_all(self,
+                  parameter_s: str = "",
+                  cell: str | None = None) -> LineProfiler | None:
         ...

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,123 +1,283 @@
-import unittest
+import os
+import re
+import shlex
+from contextlib import ExitStack
+from functools import partial
+from pathlib import Path
+from sys import stderr
+from tempfile import TemporaryDirectory
+
+import pytest
+import ubelt as ub
+
+from line_profiler import load_stats
 
 
-class TestIPython(unittest.TestCase):
-    def test_init(self):
-        """
-        CommandLine:
-            pytest -k test_init -s -v
-        """
+class tempdir:
+    """
+    Example:
+        >>> with tempdir() as td:
+        ...     assert td.is_dir()
+        ...     assert td.samefile('.')
+        ...
+        >>> assert not td.is_dir()
+    """
+    def __init__(self, *args, **kwargs):
+        self._get_tmpdir = partial(TemporaryDirectory, *args, **kwargs)
+        self._stacks = []
+
+    def __enter__(self):  # type: () -> Path
+        stack = ExitStack()
+        stack.__enter__()
+        tmpdir = Path(stack.enter_context(self._get_tmpdir()))
+        stack.enter_context(ub.ChDir(tmpdir))
+        self._stacks.append(stack)
+        return tmpdir
+
+    def __exit__(self, *_, **__):
+        self._stacks.pop().close()
+
+
+class _TestIPython:
+    @staticmethod
+    def _get_ipython_instance():
         try:
             from IPython.testing.globalipapp import get_ipython
         except ImportError:
-            import pytest
-            pytest.skip()
+            pytest.skip(reason='no `IPython`')
+        return get_ipython()
 
-        ip = get_ipython()
+    @staticmethod
+    def _emit(request, /, *args, **kwargs):
+        config = request.getfixturevalue('pytestconfig')
+        # Only emit the messages when we're not capturing
+        if config.getoption('capture') in (False, 'no'):
+            print(*args, **kwargs)
+
+
+class TestLPRun(_TestIPython):
+    """
+    CommandLine:
+        pytest -k "TestLPRun and not TestLPRunAll" -s -v
+    """
+    @pytest.mark.parametrize('modules', [None, 'calendar'])
+    def test_lprun_profiling_targets(self, request, modules):
+        """ Test ``%%lprun`` with the ``-m`` flag.
+        """
+        mods = shlex.split(modules or '')
+        if mods:
+            chunks = []
+            for mod in mods:
+                chunks.extend(['-m', mod])
+            more_flags = shlex.join(chunks)
+        else:
+            more_flags = None
+        lprof = self._test_lprun(request, more_flags)
+
+        # Check the profiling of functions
+        # - from the `-f` flag
+        assert any(getattr(func, '__name__', None) == 'func'
+                   for func in lprof.functions)
+        # - from the `-m` flag
+        for mod in mods:
+            assert any(
+                (getattr(func, '__module__', '') == mod
+                 or getattr(func, '__module__', '').startswith(mod + '.'))
+                for func in lprof.functions)
+
+    @pytest.mark.parametrize(
+        ('output', 'text'),
+        [(None, None), ('myprof.txt', True), ('myprof.lprof', False)])
+    def test_lprun_file_io(self, request, output, text):
+        """ Test ``%%lprun`` with the ``-D`` and ``-T`` flags.
+        """
+        with tempdir() as tmpdir:
+            if output:
+                out_path = tmpdir / output
+                more_flags = shlex.join(['-' + ('T' if text else 'D'),
+                                         str(out_path)])
+            else:
+                more_flags = None
+            self._test_lprun(request, more_flags)
+
+            # Check the output files (`-D` or `-T`)
+            if output:
+                assert out_path.exists()
+                assert out_path.stat().st_size
+                if not text:  # Test roundtripping
+                    load_stats(out_path)
+            else:
+                assert not os.listdir(tmpdir)
+
+    @pytest.mark.parametrize('bad', [True, False])
+    def test_lprun_timer_unit(self, request, bad):
+        """ Test ``%%lprun`` with the ``-u`` flag.
+        """
+        capsys = request.getfixturevalue('capsys')
+        if bad:  # Test invalid value
+            with pytest.raises(TypeError):
+                self._test_lprun(request, '-u not_a_number')
+            return
+        else:
+            unit = 1E-3
+            self._test_lprun(request, f'-u {unit}')
+
+        out = capsys.readouterr().out
+        # Check the timer (`-u`)
+        pattern = re.compile(r'Timer unit:\s*([^\s]+)\s*s')
+        match, = (
+            m for m in (pattern.match(line) for line in out.splitlines())
+            if m)
+        assert pytest.approx(float(match.group(1))) == unit
+
+    @pytest.mark.parametrize('skip_zero', [None, '-s', '-z'])
+    def test_lprun_skip_zero(self, request, skip_zero):
+        """ Test ``%%lprun`` with the ``-s`` and ``-z`` flags.
+        """
+        capsys = request.getfixturevalue('capsys')
+        # Throw in an unrelated module, whose timings are always zero
+        more_flags = '-m calendar'
+        if skip_zero:
+            more_flags = f'{more_flags} {skip_zero}'
+        self._test_lprun(request, more_flags)
+
+        # Check whether zero entries are skipped
+        out = capsys.readouterr().out
+
+        match = re.search(
+            r'^File:\s*.*{}calendar\.py'.format(re.escape(os.sep)),
+            out,
+            flags=re.MULTILINE)
+        assert bool(match) == (not skip_zero)
+
+    @pytest.mark.parametrize(('xc', 'raised'),
+                             [(SystemExit(0), False),
+                              (ValueError('foo'), True)])
+    def test_lprun_exception_handling(self, capsys, xc, raised):
+        ip = self._get_ipython_instance()
+        ip.run_line_magic('load_ext', 'line_profiler')
+        xc_repr = '{}({})'.format(
+            type(xc).__name__, ', '.join(repr(a) for a in xc.args))
+        ip.run_cell(
+            raw_cell=f'func = lambda: (_ for _ in ()).throw({xc_repr})')
+
+        if raised:  # Normal excepts should be bubbled up
+            with pytest.raises(type(xc)):
+                ip.run_line_magic('lprun', '-f func func()')
+            return
+
+        # Special expressions are captured and relegated to a warning
+        # message
+        ip.run_line_magic('lprun', '-f func func()')
+        out = capsys.readouterr().out
+        assert f'*** {type(xc).__name__} exception caught' in out
+
+    def _test_lprun(self, request, more_flags):
+        ip = self._get_ipython_instance()
         ip.run_line_magic('load_ext', 'line_profiler')
         ip.run_cell(raw_cell='def func():\n    return 2**20')
-        lprof = ip.run_line_magic('lprun', '-r -f func func()')
+        command = '-r -f func func()'
+        if more_flags:
+            command = f'{more_flags} {command}'
+        lprof = ip.run_line_magic('lprun', command)
 
-        timings = lprof.get_stats().timings
-        self.assertEqual(len(timings), 1)  # 1 function
+        # Check the recorded timings
+        filtered_timings = {
+            (filename, lineno, funcname): entries
+            for (filename, lineno, funcname), entries
+            in lprof.get_stats().timings.items()
+            if filename.startswith('<ipython')
+            if filename.endswith('>')}
+        assert len(filtered_timings) == 1  # 1 function
 
-        func_data, lines_data = next(iter(timings.items()))
-        print(f'func_data={func_data}')
-        print(f'lines_data={lines_data}')
-        self.assertEqual(func_data[1], 1)  # lineno of the function
-        self.assertEqual(func_data[2], "func")  # function name
-        self.assertEqual(len(lines_data), 1)  # 1 line of code
-        self.assertEqual(lines_data[0][0], 2)  # lineno
-        self.assertEqual(lines_data[0][1], 1)  # hits
+        func_data, lines_data = next(iter(filtered_timings.items()))
+        self._emit(request, f'func_data={func_data}')
+        self._emit(request, f'lines_data={lines_data}', file=stderr)
+        assert func_data[1] == 1  # lineno of the function
+        assert func_data[2] == "func"  # function name
+        assert len(lines_data) == 1  # 1 line of code
+        assert lines_data[0][0] == 2  # lineno
+        assert lines_data[0][1] == 1  # hits
 
+        return lprof
+
+
+class TestLPRunAll(_TestIPython):
     def test_lprun_all_autoprofile(self):
-        try:
-            from IPython.testing.globalipapp import get_ipython
-        except ImportError:
-            import pytest
-            pytest.skip()
-        
-        ip = get_ipython()
+        """ Test ``%%lprun_all`` without the ``-p`` flag.
+        """
+        ip = self._get_ipython_instance()
         ip.run_line_magic('load_ext', 'line_profiler')
         lprof = ip.run_cell_magic(
             'lprun_all', line='-r', cell=self.lprun_all_cell_body)
         timings = lprof.get_stats().timings
-        
+
         # 2 scopes: the module scope and an inner scope (Test.test)
-        self.assertEqual(len(timings), 2)
+        assert len(timings) == 2
 
         timings_iter = iter(timings.items())
         func_1_data, lines_1_data = next(timings_iter)
         func_2_data, lines_2_data = next(timings_iter)
         print(f'func_1_data={func_1_data}')
         print(f'lines_1_data={lines_1_data}')
-        self.assertEqual(func_1_data[1], 1)  # lineno of the module
-        self.assertEqual(len(lines_1_data), 2)  # only 2 lines were executed in this outer scope
-        self.assertEqual(lines_1_data[0][0], 1)  # lineno
-        self.assertEqual(lines_1_data[0][1], 1)  # hits
-        
+        assert func_1_data[1] == 1  # lineno of the module
+        assert len(lines_1_data) == 2  # only 2 lines were executed in this outer scope
+        assert lines_1_data[0][0] == 1  # lineno
+        assert lines_1_data[0][1] == 1  # hits
+
         print(f'func_2_data={func_2_data}')
         print(f'lines_2_data={lines_2_data}')
-        self.assertEqual(func_2_data[1], 2)  # lineno of the inner function
-        self.assertEqual(len(lines_2_data), 5)  # only 5 lines were executed in this inner scope
-        self.assertEqual(lines_2_data[1][0], 4)  # lineno
-        self.assertEqual(lines_2_data[1][1], self.loops - 1)  # hits
+        assert func_2_data[1] == 2  # lineno of the inner function
+        assert len(lines_2_data) == 5  # only 5 lines were executed in this inner scope
+        assert lines_2_data[1][0] == 4  # lineno
+        assert lines_2_data[1][1] == self.loops - 1  # hits
 
         # Check that the code is executed in the right scope and with
         # the expected side effects
-        self.assertTrue(isinstance(ip.user_ns.get("Test"), type))
-        self.assertTrue('z' in ip.user_ns)
-        self.assertTrue(ip.user_ns['z'] is None)
-    
+        assert isinstance(ip.user_ns.get("Test"), type)
+        assert ip.user_ns['z'] is None
+
     def test_lprun_all_autoprofile_toplevel(self):
-        try:
-            from IPython.testing.globalipapp import get_ipython
-        except ImportError:
-            import pytest
-            pytest.skip()
-        
-        ip = get_ipython()
+        """ Test ``%%lprun_all`` with the ``-p`` flag.
+        """
+        ip = self._get_ipython_instance()
         ip.run_line_magic('load_ext', 'line_profiler')
         lprof = ip.run_cell_magic(
             'lprun_all', line='-r -p', cell=self.lprun_all_cell_body)
         timings = lprof.get_stats().timings
-        
+
         # 1 scope: the module scope
-        self.assertEqual(len(timings), 1)
+        assert len(timings) == 1
 
         timings_iter = iter(timings.items())
         func_data, lines_data = next(timings_iter)
         print(f'func_data={func_data}')
         print(f'lines_data={lines_data}')
-        self.assertEqual(func_data[1], 1)  # lineno of the module
-        self.assertEqual(len(lines_data), 2)  # only 2 lines were executed in this outer scope
-        self.assertEqual(lines_data[0][0], 1)  # lineno
-        self.assertEqual(lines_data[0][1], 1)  # hits
+        assert func_data[1] == 1  # lineno of the module
+        assert len(lines_data) == 2  # only 2 lines were executed in this outer scope
+        assert lines_data[0][0] == 1  # lineno
+        assert lines_data[0][1] == 1  # hits
 
         # Check that the code is executed in the right scope and with
         # the expected side effects
-        self.assertTrue(isinstance(ip.user_ns.get("Test"), type))
-        self.assertTrue('z' in ip.user_ns)
-        self.assertTrue(ip.user_ns['z'] is None)
-    
+        assert isinstance(ip.user_ns.get("Test"), type)
+        assert ip.user_ns['z'] is None
+
     def test_lprun_all_timetaken(self):
-        try:
-            from IPython.testing.globalipapp import get_ipython
-        except ImportError:
-            import pytest
-            pytest.skip()
-            
-        ip = get_ipython()
+        """ Test ``%%lprun_all`` with the ``-t`` flag.
+        """
+        ip = self._get_ipython_instance()
         ip.run_line_magic('load_ext', 'line_profiler')
-        ip.run_cell_magic('lprun_all', line='-t', cell=self.lprun_all_cell_body)
+        result = ip.run_cell_magic(
+            'lprun_all', line='-t', cell=self.lprun_all_cell_body)
+        assert result is None  # No `-r` flag -> profiler not returned
 
         # Check that the code is executed in the right scope and with
         # the expected side effects
-        self.assertTrue(isinstance(ip.user_ns.get("Test"), type))
-        self.assertTrue('z' in ip.user_ns)
-        self.assertTrue(ip.user_ns['z'] is None)
+        assert isinstance(ip.user_ns.get("Test"), type)
+        assert ip.user_ns['z'] is None
         # Check that the elapsed time is written to the right scope
-        self.assertTrue(ip.user_ns.get("_total_time_taken", None) is not None)
+        assert ip.user_ns.get("_total_time_taken", None) is not None
 
     # This example has 2 scopes
     # - The top level (module) scope, and


### PR DESCRIPTION
Code changes
---
- Refactored `line_profiler/ipython_extensions.py::LineProfilerMagics.lprun()` and `.lprun_all()` to unify code paths
- Fixed error message written by `.lprun` ("Could not find module [...]" -> "Could not find **function** [...]") which an `-f` target can't be profiled
- Fixed edge case where `.lprun_all()` gets a blank `cell`
- Fixed misuse of cell magic (`%lprun_all` -> `%%lprun_all`) in `.lprun_all.__doc__`
- No longer enclosing the profiled code in a dummy function. This has the following benefits:
  - Fixing bug where local names defined in the `%%lprun_all`-ed code block are not available in the subsequent namespace
  - Making profiling output cleaner; instead of
    ```
    [...]  Line Contents
    ====================
    [...]  def _lprun_cell():
    [...]      content
    ```
    we now just have
    ```
    [...]  Line Contents
    ====================
    [...]  content
    ```
- Removed the now-unused `SkipWrapper`
- Updated docstring formats to be more Sphinx-friendly

Test changes
---
- Refactored `tests/test_ipython.py::TestIPython` into the following test classes:
  - `TestLPRun`:  
    - Tests for `%lprun`, its specific options (`-m`, `-s`), and options common to `%lprun` and `%%lprun_all` (`-D`, `-T`, `-u`, `-z`)
    - Supersedes `TestIPython.test_init()`
  - `TestLPRunAll`:  
    - Tests for `%%lprun_all`, migrated from `TestIPython.test_lprun_all_*()`
    - Added check that cell namespace changes are correctly handled
- File coverage for `line_profiler.ipython_extension` is now at 98% compared to the previous 70-something