### PR TITLE
Hotfixes for failing tests on pyutils/line_profiler#383

### DIFF
--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -536,7 +536,8 @@ class LineProfilerMagics(Magics):
                 with prof:
                     run = self._run_and_profile(
                         prof, parsed, tf.name, exec, code,
-                        globals=ip.user_global_ns, locals=ip.user_ns)
+                        # `globals` and `locals`
+                        ip.user_global_ns, ip.user_ns)
         finally:
             os.unlink(tf.name)
         if "t" in parsed.opts:

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -93,15 +93,14 @@ class TestLPRun(_TestIPython):
         """
         with tempdir() as tmpdir:
             if output:
-                out_path = tmpdir / output
-                more_flags = shlex.join(['-' + ('T' if text else 'D'),
-                                         str(out_path)])
+                more_flags = shlex.join(['-' + ('T' if text else 'D'), output])
             else:
                 more_flags = None
             self._test_lprun(request, more_flags)
 
             # Check the output files (`-D` or `-T`)
             if output:
+                out_path = tmpdir / output
                 assert out_path.exists()
                 assert out_path.stat().st_size
                 if not text:  # Test roundtripping

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -62,7 +62,7 @@ class TestLPRun(_TestIPython):
     """
     @pytest.mark.parametrize('modules', [None, 'calendar'])
     def test_lprun_profiling_targets(self, request, modules):
-        """ Test ``%%lprun`` with the ``-m`` flag.
+        """ Test ``%lprun`` with the ``-m`` flag.
         """
         mods = shlex.split(modules or '')
         if mods:
@@ -89,7 +89,7 @@ class TestLPRun(_TestIPython):
         ('output', 'text'),
         [(None, None), ('myprof.txt', True), ('myprof.lprof', False)])
     def test_lprun_file_io(self, request, output, text):
-        """ Test ``%%lprun`` with the ``-D`` and ``-T`` flags.
+        """ Test ``%lprun`` with the ``-D`` and ``-T`` flags.
         """
         with tempdir() as tmpdir:
             if output:
@@ -111,7 +111,7 @@ class TestLPRun(_TestIPython):
 
     @pytest.mark.parametrize('bad', [True, False])
     def test_lprun_timer_unit(self, request, bad):
-        """ Test ``%%lprun`` with the ``-u`` flag.
+        """ Test ``%lprun`` with the ``-u`` flag.
         """
         capsys = request.getfixturevalue('capsys')
         if bad:  # Test invalid value
@@ -132,7 +132,7 @@ class TestLPRun(_TestIPython):
 
     @pytest.mark.parametrize('skip_zero', [None, '-s', '-z'])
     def test_lprun_skip_zero(self, request, skip_zero):
-        """ Test ``%%lprun`` with the ``-s`` and ``-z`` flags.
+        """ Test ``%lprun`` with the ``-s`` and ``-z`` flags.
         """
         capsys = request.getfixturevalue('capsys')
         # Throw in an unrelated module, whose timings are always zero
@@ -154,6 +154,8 @@ class TestLPRun(_TestIPython):
                              [(SystemExit(0), False),
                               (ValueError('foo'), True)])
     def test_lprun_exception_handling(self, capsys, xc, raised):
+        """ Test ``%lprun``-ing a function which raises exceptions.
+        """
         ip = self._get_ipython_instance()
         ip.run_line_magic('load_ext', 'line_profiler')
         xc_repr = '{}({})'.format(
@@ -203,6 +205,10 @@ class TestLPRun(_TestIPython):
 
 
 class TestLPRunAll(_TestIPython):
+    """
+    CommandLine:
+        pytest -k TestLPRunAll -s -v
+    """
     def test_lprun_all_autoprofile(self):
         """ Test ``%%lprun_all`` without the ``-p`` flag.
         """


### PR DESCRIPTION
- `line_profiler/ipython_extension.py::LineProfilerMagics.lprun_all()`:  
  Fixed invalid invocation of `exec()` since older Pythona don't allow calling it with `globals` and `locals` as keyword args ([example failed pipeline](https://github.com/pyutils/line_profiler/actions/runs/16996593880/job/48190702967?pr=383))
- `tests/test_ipython.py`:
  - `TestLPRun`:
    - `test_lprun_{profiling_targets,file_io,timer_unit,skip_zero}.__doc__`:  
      Fixed wrong line magic (`%%lprun` -> `%lprun`)
    - `test_lprun_exception_handling.__doc__`:  
      Added missing docstring
  - `TestLPRunAll`:  
    - `__doc__`:  
      Added docstring
    - `test_lprun_file_io()`:  
      Now only using basenames with the `-D` and `-T` to circumvent path-separator issues on Windows ([example failed pipeline](https://github.com/pyutils/line_profiler/actions/runs/16996593880/job/48190702959?pr=383))