### PR TITLE
Yet another hotfix

### DIFF
--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -28,7 +28,7 @@ help mechanism::
 
     In [1]: %lprun?
 
-.. |lprun| replace:: :py:data:`%%lprun <LineProfilerMagics.lprun>`
+.. |lprun| replace:: :py:data:`%lprun <LineProfilerMagics.lprun>`
 .. |lprun_all| replace:: :py:data:`%%lprun_all <LineProfilerMagics.lprun_all>`
 .. |builtins| replace:: :py:mod:`__builtins__ <builtins>`
 """

--- a/line_profiler/ipython_extension.py
+++ b/line_profiler/ipython_extension.py
@@ -209,6 +209,7 @@ class _RunAndProfileResult:
 class _PatchProfilerIntoBuiltins:
     """
     Example:
+        >>> # xdoctest: +REQUIRES(module:IPython)
         >>> import builtins
         >>> from line_profiler import LineProfiler
         >>>
@@ -221,6 +222,12 @@ class _PatchProfilerIntoBuiltins:
         Traceback (most recent call last):
           ...
         AttributeError: ...
+
+    Note:
+        This class doesn't itself need :py:mod:`IPython`, but it
+        resides in a module that does. To reduce complications, we just
+        skip this doctest if :py:mod:`IPython` (and hence this module)
+        can't be imported.
     """
     def __init__(self, prof=None):
         # type: (LineProfiler | None) -> None


### PR DESCRIPTION
The last pipeline failed (e.g. https://github.com/pyutils/line_profiler/actions/runs/17001620057/job/48205423249) because:
- In the environments of the failing jobs `IPython` isn't installed.
- `line_profiler/ipython_extension.py` is thus not import-able.
- Nonetheles, the doctest `line_profiler/ipython_extension.py::_PatchProfilerIntoBuiltins:0` is collected, which of course fails because the class it uses lives in said module.

The PR fixes this by conditionally skipping the doctest using the `xdoctest: +REQUIRES(module:IPython)` directive. A typo in the module docstring is also fixed (`%%lprun` -> `%lprun`).